### PR TITLE
191 add app for susbtrates layers and growth run to movpe2 in ikz plugin

### DIFF
--- a/IKZ_plugin/pyproject.toml
+++ b/IKZ_plugin/pyproject.toml
@@ -132,5 +132,6 @@ dir_sol_schema = "ikz_plugin.directional_solidification:schema"
 dir_sol_manual_protocol_excel_parser = "ikz_plugin.directional_solidification:excel_parser"
 czochralski_schema = "ikz_plugin.czochralski:schema"
 czochralski_multilog_parser = "ikz_plugin.czochralski:parser"
+movpe_app = "ikz_plugin.movpe.movpe_app:movpesubstrateapp"
 
 

--- a/IKZ_plugin/src/ikz_plugin/movpe/movpe_app/__init__.py
+++ b/IKZ_plugin/src/ikz_plugin/movpe/movpe_app/__init__.py
@@ -1,0 +1,65 @@
+import yaml
+from nomad.config.models.plugins import AppEntryPoint
+from nomad.config.models.ui import (
+    App,
+    Column,
+    Columns,
+    FilterMenu,
+    FilterMenus,
+    Filters,
+)
+
+movpesubstrateapp = AppEntryPoint(
+    name='MOVPESubstratesApp',
+    description='Explore MOVPE substrates.',
+    app=App(
+        label='MOVPESubstratesApp',
+        path='movpesubstrateapp',
+        category='MOVPE',
+        columns=Columns(
+            selected=[
+                #'entry_id', name, type, manufacturer, model, serial number, location, description
+                'data.name#ikz_plugin.movpe.schema.SubstrateMovpe',
+                'data.supplier#ikz_plugin.movpe.schema.SubstrateMovpe',
+                'data.datetime#ikz_plugin.movpe.schema.SubstrateMovpe',
+                'data.lab_id#ikz_plugin.movpe.schema.SubstrateMovpe',
+            ],
+            options={
+                #'entry_id': Column(),
+                'data.name#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.name#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.supplier#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.datetime#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.lab_id#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.etching#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.annealing#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.re_etching#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.re_annealing#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.epi_ready#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.dopants.elements#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.dopants.doping_level#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.crystal_properties.orientation#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.crystal_properties.miscut.angle#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.electronic_properties.conductivity_type#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+            },
+        ),
+        filter_menus=FilterMenus(
+            options={
+                'material': FilterMenu(label='Material'),
+                'eln': FilterMenu(label='Electronic Lab Notebook'),
+                'custom_quantities': FilterMenu(label='User Defined Quantities'),
+                'author': FilterMenu(label='Author / Origin / Dataset'),
+                'metadata': FilterMenu(label='Visibility / IDs / Schema'),
+            }
+        ),
+        filters=Filters(
+            include=['*#ikz_plugin.movpe.schema.SubstrateMovpe'],
+        ),
+        filters_locked={
+            'section_defs.definition_qualified_name': [
+                'ikz_plugin.movpe.schema.SubstrateMovpe',
+                #'nomad_ikz_fz.schema_packages.mypackage.Coil',
+            ],
+        },
+    ),
+)

--- a/IKZ_plugin/src/ikz_plugin/movpe/movpe_app/__init__.py
+++ b/IKZ_plugin/src/ikz_plugin/movpe/movpe_app/__init__.py
@@ -10,128 +10,83 @@ from nomad.config.models.ui import (
 )
 
 movpesubstrateapp = AppEntryPoint(
-    name="MOVPESubstratesApp",
-    description="Explore MOVPE substrates.",
+    name='MOVPESubstratesApp',
+    description='Explore MOVPE substrates.',
     app=App(
-        label="MOVPE Substrates",
-        path="movpesubstrateapp",
-        category="MOVPE",
+        label='MOVPE Substrates',
+        path='movpesubstrateapp',
+        category='MOVPE',
         columns=Columns(
             selected=[
-                #'entry_id', name, type, manufacturer, model, serial number, location, description
-                "data.name#ikz_plugin.movpe.schema.SubstrateMovpe",
-                "data.supplier#ikz_plugin.movpe.schema.SubstrateMovpe",
-                "data.datetime#ikz_plugin.movpe.schema.SubstrateMovpe",
-                "data.lab_id#ikz_plugin.movpe.schema.SubstrateMovpe",
-                "data.crystal_properties.orientation#ikz_plugin.movpe.schema.SubstrateMovpe",
-                "data.crystal_properties.miscut.angle#ikz_plugin.movpe.schema.SubstrateMovpe",
-                "data.crystal_properties.miscut.orientation#ikz_plugin.movpe.schema.SubstrateMovpe",
-                "data.geometry.length#ikz_plugin.movpe.schema.SubstrateMovpe",
-                "data.geometry.width#ikz_plugin.movpe.schema.SubstrateMovpe",
-                "data.electronic_properties.conductivity_type#ikz_plugin.movpe.schema.SubstrateMovpe",
-                "data.tags#ikz_plugin.movpe.schema.SubstrateMovpe",
-                "data.description#ikz_plugin.movpe.schema.SubstrateMovpe",
+                'data.name#ikz_plugin.movpe.schema.SubstrateMovpe',
+                'data.supplier#ikz_plugin.movpe.schema.SubstrateMovpe',
+                'data.datetime#ikz_plugin.movpe.schema.SubstrateMovpe',
+                'data.lab_id#ikz_plugin.movpe.schema.SubstrateMovpe',
+                'data.crystal_properties.orientation#ikz_plugin.movpe.schema.SubstrateMovpe',
+                'data.crystal_properties.miscut.angle#ikz_plugin.movpe.schema.SubstrateMovpe',
+                'data.crystal_properties.miscut.orientation#ikz_plugin.movpe.schema.SubstrateMovpe',
+                'data.geometry.length#ikz_plugin.movpe.schema.SubstrateMovpe',
+                'data.geometry.width#ikz_plugin.movpe.schema.SubstrateMovpe',
+                'data.electronic_properties.conductivity_type#ikz_plugin.movpe.schema.SubstrateMovpe',
+                'data.tags#ikz_plugin.movpe.schema.SubstrateMovpe',
+                'data.description#ikz_plugin.movpe.schema.SubstrateMovpe',
             ],
             options={
-                #'entry_id': Column(),
-                "data.name#ikz_plugin.movpe.schema.SubstrateMovpe": Column(),
-                "data.supplier#ikz_plugin.movpe.schema.SubstrateMovpe": Column(
-                    label="Supplier ID"
+                'data.name#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.supplier#ikz_plugin.movpe.schema.SubstrateMovpe': Column(
+                    label='Supplier ID'
                 ),
-                "data.datetime#ikz_plugin.movpe.schema.SubstrateMovpe": Column(
-                    label="Delivery Date"
+                'data.datetime#ikz_plugin.movpe.schema.SubstrateMovpe': Column(
+                    label='Delivery Date'
                 ),
-                "data.lab_id#ikz_plugin.movpe.schema.SubstrateMovpe": Column(
-                    label="Substrate ID"
+                'data.lab_id#ikz_plugin.movpe.schema.SubstrateMovpe': Column(
+                    label='Substrate ID'
                 ),
-                "data.tags#ikz_plugin.movpe.schema.SubstrateMovpe": Column(
-                    label="Substrate Box"
+                'data.tags#ikz_plugin.movpe.schema.SubstrateMovpe': Column(
+                    label='Substrate Box'
                 ),
-                "data.description#ikz_plugin.movpe.schema.SubstrateMovpe": Column(
-                    label="Comment"
+                'data.description#ikz_plugin.movpe.schema.SubstrateMovpe': Column(
+                    label='Comment'
                 ),
-                "data.etching#ikz_plugin.movpe.schema.SubstrateMovpe": Column(),
-                "data.annealing#ikz_plugin.movpe.schema.SubstrateMovpe": Column(),
-                "data.re_etching#ikz_plugin.movpe.schema.SubstrateMovpe": Column(),
-                "data.re_annealing#ikz_plugin.movpe.schema.SubstrateMovpe": Column(),
-                "data.epi_ready#ikz_plugin.movpe.schema.SubstrateMovpe": Column(),
-                "data.geometry.length#ikz_plugin.movpe.schema.SubstrateMovpe": Column(
-                    label="Length", unit="mm"
+                'data.etching#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.annealing#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.re_etching#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.re_annealing#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.epi_ready#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.geometry.length#ikz_plugin.movpe.schema.SubstrateMovpe': Column(
+                    label='Length', unit='mm'
                 ),
-                "data.geometry.width#ikz_plugin.movpe.schema.SubstrateMovpe": Column(
-                    label="Width", unit="mm"
+                'data.geometry.width#ikz_plugin.movpe.schema.SubstrateMovpe': Column(
+                    label='Width', unit='mm'
                 ),
-                "data.dopants.elements#ikz_plugin.movpe.schema.SubstrateMovpe": Column(),
-                "data.dopants.doping_level#ikz_plugin.movpe.schema.SubstrateMovpe": Column(),
-                "data.crystal_properties.orientation#ikz_plugin.movpe.schema.SubstrateMovpe": Column(),
-                "data.crystal_properties.miscut.angle#ikz_plugin.movpe.schema.SubstrateMovpe": Column(
-                    label="Miscut Angle"
+                'data.dopants.elements#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.dopants.doping_level#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.crystal_properties.orientation#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.crystal_properties.miscut.angle#ikz_plugin.movpe.schema.SubstrateMovpe': Column(
+                    label='Miscut Angle'
                 ),
-                "data.crystal_properties.miscut.orientation#ikz_plugin.movpe.schema.SubstrateMovpe": Column(
-                    label="Miscut Orientation"
+                'data.crystal_properties.miscut.orientation#ikz_plugin.movpe.schema.SubstrateMovpe': Column(
+                    label='Miscut Orientation'
                 ),
-                "data.electronic_properties.conductivity_type#ikz_plugin.movpe.schema.SubstrateMovpe": Column(),
+                'data.electronic_properties.conductivity_type#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
             },
         ),
         filter_menus=FilterMenus(
             options={
-                "material": FilterMenu(label="Material"),
-                "eln": FilterMenu(label="Electronic Lab Notebook"),
-                "custom_quantities": FilterMenu(label="User Defined Quantities"),
-                "author": FilterMenu(label="Author / Origin / Dataset"),
-                "metadata": FilterMenu(label="Visibility / IDs / Schema"),
+                'material': FilterMenu(label='Material'),
+                'eln': FilterMenu(label='Electronic Lab Notebook'),
+                'custom_quantities': FilterMenu(label='User Defined Quantities'),
+                'author': FilterMenu(label='Author / Origin / Dataset'),
+                'metadata': FilterMenu(label='Visibility / IDs / Schema'),
             }
         ),
         filters=Filters(
-            include=["*#ikz_plugin.movpe.schema.SubstrateMovpe"],
+            include=['*#ikz_plugin.movpe.schema.SubstrateMovpe'],
         ),
         filters_locked={
-            "section_defs.definition_qualified_name": [
-                "ikz_plugin.movpe.schema.SubstrateMovpe",
-                #'nomad_ikz_fz.schema_packages.mypackage.Coil',
+            'section_defs.definition_qualified_name': [
+                'ikz_plugin.movpe.schema.SubstrateMovpe',
             ],
         },
     ),
 )
-
-# movpeprocessapp = AppEntryPoint(
-#     name='MOVPEProcessApp',
-#     description='Explore MOVPE processes.',
-#     app=App(
-#         label='MOVPEProcessApp',
-#         path='movpeprocessapp',
-#         category='MOVPE',
-#         columns=Columns(
-#             selected=[
-#                 #'entry_id', name, type, manufacturer, model, serial number, location, description
-#                 'data.name#ikz_plugin.movpe.schema.SubstrateMovpe',
-#                 'data.supplier#ikz_plugin.movpe.schema.SubstrateMovpe',
-#                 'data.datetime#ikz_plugin.movpe.schema.SubstrateMovpe',
-#                 'data.lab_id#ikz_plugin.movpe.schema.SubstrateMovpe',
-#             ],
-#             options={
-#                 #'entry_id': Column(),
-#                 'data.name#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
-
-#             },
-#         ),
-#         filter_menus=FilterMenus(
-#             options={
-#                 'material': FilterMenu(label='Material'),
-#                 'eln': FilterMenu(label='Electronic Lab Notebook'),
-#                 'custom_quantities': FilterMenu(label='User Defined Quantities'),
-#                 'author': FilterMenu(label='Author / Origin / Dataset'),
-#                 'metadata': FilterMenu(label='Visibility / IDs / Schema'),
-#             }
-#         ),
-#         filters=Filters(
-#             include=['*#ikz_plugin.movpe.schema.SubstrateMovpe'],
-#         ),
-#         filters_locked={
-#             'section_defs.definition_qualified_name': [
-#                 'ikz_plugin.movpe.schema.SubstrateMovpe',
-#                 #'nomad_ikz_fz.schema_packages.mypackage.Coil',
-#             ],
-#         },
-#     ),
-# )

--- a/IKZ_plugin/src/ikz_plugin/movpe/movpe_app/__init__.py
+++ b/IKZ_plugin/src/ikz_plugin/movpe/movpe_app/__init__.py
@@ -13,7 +13,7 @@ movpesubstrateapp = AppEntryPoint(
     name='MOVPESubstratesApp',
     description='Explore MOVPE substrates.',
     app=App(
-        label='MOVPESubstratesApp',
+        label='MOVPE Substrates',
         path='movpesubstrateapp',
         category='MOVPE',
         columns=Columns(
@@ -23,23 +23,53 @@ movpesubstrateapp = AppEntryPoint(
                 'data.supplier#ikz_plugin.movpe.schema.SubstrateMovpe',
                 'data.datetime#ikz_plugin.movpe.schema.SubstrateMovpe',
                 'data.lab_id#ikz_plugin.movpe.schema.SubstrateMovpe',
+                'data.crystal_properties.orientation#ikz_plugin.movpe.schema.SubstrateMovpe',
+                'data.crystal_properties.miscut.angle#ikz_plugin.movpe.schema.SubstrateMovpe',
+                'data.crystal_properties.miscut.orientation#ikz_plugin.movpe.schema.SubstrateMovpe',
+                'data.geometry.length#ikz_plugin.movpe.schema.SubstrateMovpe',
+                'data.geometry.width#ikz_plugin.movpe.schema.SubstrateMovpe',
+                'data.electronic_properties.conductivity_type#ikz_plugin.movpe.schema.SubstrateMovpe',
+                'data.tags#ikz_plugin.movpe.schema.SubstrateMovpe',
+                'data.description#ikz_plugin.movpe.schema.SubstrateMovpe',
             ],
             options={
                 #'entry_id': Column(),
                 'data.name#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
-                'data.name#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
-                'data.supplier#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
-                'data.datetime#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
-                'data.lab_id#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.supplier#ikz_plugin.movpe.schema.SubstrateMovpe': Column(
+                    label='Supplier ID'
+                ),
+                'data.datetime#ikz_plugin.movpe.schema.SubstrateMovpe': Column(
+                    label='Delivery Date'
+                ),
+                'data.lab_id#ikz_plugin.movpe.schema.SubstrateMovpe': Column(
+                    label='Substrate ID'
+                ),
+                'data.tags#ikz_plugin.movpe.schema.SubstrateMovpe': Column(
+                    label='Substrate Box'
+                ),
+                'data.description#ikz_plugin.movpe.schema.SubstrateMovpe': Column(
+                    label='Comment'
+                ),
                 'data.etching#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
                 'data.annealing#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
                 'data.re_etching#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
                 'data.re_annealing#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
                 'data.epi_ready#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.geometry.length#ikz_plugin.movpe.schema.SubstrateMovpe': Column(
+                    label='Length', unit='mm'
+                ),
+                'data.geometry.width#ikz_plugin.movpe.schema.SubstrateMovpe': Column(
+                    label='Width', unit='mm'
+                ),
                 'data.dopants.elements#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
                 'data.dopants.doping_level#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
                 'data.crystal_properties.orientation#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
-                'data.crystal_properties.miscut.angle#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+                'data.crystal_properties.miscut.angle#ikz_plugin.movpe.schema.SubstrateMovpe': Column(
+                    label='Miscut Angle'
+                ),
+                'data.crystal_properties.miscut.orientation#ikz_plugin.movpe.schema.SubstrateMovpe': Column(
+                    label='Miscut Orientation'
+                ),
                 'data.electronic_properties.conductivity_type#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
             },
         ),
@@ -63,3 +93,45 @@ movpesubstrateapp = AppEntryPoint(
         },
     ),
 )
+
+# movpeprocessapp = AppEntryPoint(
+#     name='MOVPEProcessApp',
+#     description='Explore MOVPE processes.',
+#     app=App(
+#         label='MOVPEProcessApp',
+#         path='movpeprocessapp',
+#         category='MOVPE',
+#         columns=Columns(
+#             selected=[
+#                 #'entry_id', name, type, manufacturer, model, serial number, location, description
+#                 'data.name#ikz_plugin.movpe.schema.SubstrateMovpe',
+#                 'data.supplier#ikz_plugin.movpe.schema.SubstrateMovpe',
+#                 'data.datetime#ikz_plugin.movpe.schema.SubstrateMovpe',
+#                 'data.lab_id#ikz_plugin.movpe.schema.SubstrateMovpe',
+#             ],
+#             options={
+#                 #'entry_id': Column(),
+#                 'data.name#ikz_plugin.movpe.schema.SubstrateMovpe': Column(),
+
+#             },
+#         ),
+#         filter_menus=FilterMenus(
+#             options={
+#                 'material': FilterMenu(label='Material'),
+#                 'eln': FilterMenu(label='Electronic Lab Notebook'),
+#                 'custom_quantities': FilterMenu(label='User Defined Quantities'),
+#                 'author': FilterMenu(label='Author / Origin / Dataset'),
+#                 'metadata': FilterMenu(label='Visibility / IDs / Schema'),
+#             }
+#         ),
+#         filters=Filters(
+#             include=['*#ikz_plugin.movpe.schema.SubstrateMovpe'],
+#         ),
+#         filters_locked={
+#             'section_defs.definition_qualified_name': [
+#                 'ikz_plugin.movpe.schema.SubstrateMovpe',
+#                 #'nomad_ikz_fz.schema_packages.mypackage.Coil',
+#             ],
+#         },
+#     ),
+# )


### PR DESCRIPTION
I added a first version of a Substrate app for MOVPE. It will provide a table with the most important quantities according to Ta-Shuns data revision. Additional search widgets can be added later.
![grafik](https://github.com/user-attachments/assets/9ff6f377-9bd4-4b22-b095-b6c8eceb1847)
