### PR TITLE
Fix transmission

### DIFF
--- a/transmission/transmission_plugin/uv_vis_nir_transmission_plugin/src/transmission/schema.py
+++ b/transmission/transmission_plugin/uv_vis_nir_transmission_plugin/src/transmission/schema.py
@@ -799,7 +799,9 @@ class UVVisNirTransmissionResult(MeasurementResult):
     )
     absorbance = Quantity(
         type=np.float64,
-        description='Calculated absorbance ranging from 0 to 1.',
+        description="""
+        Calculated absorbance using the relation A = -log(T), where T denotes
+        transmittance.""",
         shape=['*'],
         unit='dimensionless',
         a_plot={'x': 'array_index', 'y': 'absorbance'},

--- a/transmission/transmission_plugin/uv_vis_nir_transmission_plugin/src/transmission/schema.py
+++ b/transmission/transmission_plugin/uv_vis_nir_transmission_plugin/src/transmission/schema.py
@@ -579,8 +579,8 @@ class MonochromatorSlitWidth(SettingOverWavelengthRange):
             properties=SectionProperties(
                 order=[
                     'name',
-                    'wavelength_upper_limit',
                     'wavelength_lower_limit',
+                    'wavelength_upper_limit',
                     'slit_width_servo',
                     'slit_width',
                 ],
@@ -616,8 +616,8 @@ class MonochromatorSettings(SettingOverWavelengthRange):
             properties=SectionProperties(
                 order=[
                     'name',
-                    'wavelength_upper_limit',
                     'wavelength_lower_limit',
+                    'wavelength_upper_limit',
                     'monochromator',
                 ],
             ),
@@ -641,8 +641,8 @@ class NIRGain(SettingOverWavelengthRange):
             properties=SectionProperties(
                 order=[
                     'name',
-                    'wavelength_upper_limit',
                     'wavelength_lower_limit',
+                    'wavelength_upper_limit',
                     'nir_gain_factor',
                 ],
             ),
@@ -667,8 +667,8 @@ class IntegrationTime(SettingOverWavelengthRange):
             properties=SectionProperties(
                 order=[
                     'name',
-                    'wavelength_upper_limit',
                     'wavelength_lower_limit',
+                    'wavelength_upper_limit',
                     'integration_time',
                 ],
             ),
@@ -695,8 +695,8 @@ class DetectorSettings(SettingOverWavelengthRange):
             properties=SectionProperties(
                 order=[
                     'name',
-                    'wavelength_upper_limit',
                     'wavelength_lower_limit',
+                    'wavelength_upper_limit',
                     'detector',
                 ],
             ),
@@ -720,8 +720,8 @@ class LampSettings(SettingOverWavelengthRange):
             properties=SectionProperties(
                 order=[
                     'name',
-                    'wavelength_upper_limit',
                     'wavelength_lower_limit',
+                    'wavelength_upper_limit',
                     'lamp',
                 ],
             ),

--- a/transmission/transmission_plugin/uv_vis_nir_transmission_plugin/src/transmission/schema.py
+++ b/transmission/transmission_plugin/uv_vis_nir_transmission_plugin/src/transmission/schema.py
@@ -1195,14 +1195,14 @@ class ELNUVVisNirTransmission(UVVisNirTransmission, PlotSection, EntryData):
         if data_dict['is_tungsten_lamp_used']:
             lamps.append('Tungsten')
         try:
-            for i, light_source in enumerate(
-                instrument_reference.reference.light_sources
-            ):
+            i = 0
+            for light_source in instrument_reference.reference.light_sources:
                 if light_source.type in lamps:
                     transmission.m_setdefault(f'transmission_settings/light_source/{i}')
                     transmission.transmission_settings.light_source[
                         i
                     ].lamp = light_source
+                    i += 1
         except Exception as e:
             logger.warning(
                 f'Failed to add lamp settings. Error: {e}',
@@ -1249,10 +1249,12 @@ class ELNUVVisNirTransmission(UVVisNirTransmission, PlotSection, EntryData):
             )
             detector_list = ['PMT', 'InGaAs']
         try:
-            for i, detector in enumerate(instrument_reference.reference.detectors):
+            i = 0
+            for detector in instrument_reference.reference.detectors:
                 if detector.type in detector_list:
                     transmission.m_setdefault(f'transmission_settings/detector/{i}')
                     transmission.transmission_settings.detector[i].detector = detector
+                    i += 1
         except Exception as e:
             logger.warning(
                 f'Failed to add detector settings. Error: {e}',
@@ -1275,13 +1277,13 @@ class ELNUVVisNirTransmission(UVVisNirTransmission, PlotSection, EntryData):
 
         # add settings: monochromator
         try:
-            for i, monochromator in enumerate(
-                instrument_reference.reference.monochromators
-            ):
+            i = 0
+            for monochromator in instrument_reference.reference.monochromators:
                 transmission.m_setdefault(f'transmission_settings/monochromator/{i}')
                 transmission.transmission_settings.monochromator[
                     i
                 ].monochromator = monochromator
+                i += 1
         except Exception as e:
             logger.warning(
                 f'Failed to add monochromator settings. Error: {e}',


### PR DESCRIPTION
- Avoids increment of `i` that is used in `m_setdefault` when the instrument component is not used.
- Modifies `absorbance` description
- Re-orders wavelength limits